### PR TITLE
Replace unknown proposal values with placeholders

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,6 @@
 export * from "./bridge";
 export * from "./constants";
 export * from "./proposal";
+export * from "./replacer";
 export * from "./safe";
 export * from "./snapshot";

--- a/src/lib/proposal.ts
+++ b/src/lib/proposal.ts
@@ -7,6 +7,8 @@ export type JsonMetaTransaction = Record<
   string
 > & { operation: number };
 
+export type ProposalSteps = JsonMetaTransaction[][];
+
 export function transformMetaTransaction(
   tx: MetaTransaction,
 ): JsonMetaTransaction {

--- a/src/lib/replacer.ts
+++ b/src/lib/replacer.ts
@@ -1,0 +1,129 @@
+import { BigNumber, BigNumberish, ethers, utils } from "ethers";
+
+import { ProposalSteps } from ".";
+
+const keccak = utils.id;
+
+export interface Placeholder {
+  value: string;
+}
+
+export type StringReplacements = Record<string, string>;
+export type Replacements = Record<string, BigNumberish>;
+
+export class CalldataReplacer {
+  private placeholders: Map<string, Placeholder>;
+  private seed: string;
+
+  constructor(seed?: string) {
+    this.seed = keccak(seed ?? Math.random().toString());
+    this.placeholders = new Map();
+  }
+
+  generateUint256Placeholder(id: string): BigNumber {
+    if (this.placeholders.has(id)) {
+      throw new Error(
+        `Id "${id}" has already been used to identify replacement value. Please choose a different string.`,
+      );
+    }
+
+    const replacement = keccak(this.seed + id);
+    this.placeholders.set(id, { value: replacement.slice(2) });
+    return BigNumber.from(replacement);
+  }
+
+  replaceAllWithStrings(calldata: string, replacements: StringReplacements) {
+    const placeholderKeys = [...this.placeholders.keys()];
+    const replacedKeys = Object.keys(replacements);
+    const missingKeys = placeholderKeys.filter(
+      (key) => !replacedKeys.includes(key),
+    );
+    const excessKeys = replacedKeys.filter(
+      (key) => !placeholderKeys.includes(key),
+    );
+    if (missingKeys.length !== 0) {
+      throw new Error(
+        `The following keys should be replaced and are missing: ${missingKeys.join(
+          " ",
+        )}`,
+      );
+    }
+    if (excessKeys.length !== 0) {
+      throw new Error(
+        `The following keys were specified to be replaced but the corresponding placeholder was not found: ${excessKeys.join(
+          " ",
+        )}`,
+      );
+    }
+
+    let updatedCalldata = calldata.toLowerCase();
+    for (const [key, value] of Object.entries(replacements)) {
+      // The checks above guarantee that the key has a placeholder.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const placeholder = this.placeholders.get(key)!;
+      updatedCalldata = updatedCalldata.replace(
+        new RegExp(placeholder.value, "g"),
+        value,
+      );
+    }
+    return updatedCalldata;
+  }
+
+  replaceAll(calldata: string, replacements: Replacements): string {
+    const stringReplacements = Object.fromEntries(
+      Object.entries(replacements).map(([key, value]) => [
+        key,
+        bigNumberTo32Bytes(value),
+      ]),
+    );
+
+    return this.replaceAllWithStrings(calldata, stringReplacements);
+  }
+
+  private replaceAllInProposalWithMethod<
+    T extends "replaceAll" | "replaceAllWithStrings",
+  >(
+    method: T,
+    steps: ProposalSteps,
+    replacements: Parameters<typeof this[T]>[1],
+  ): ProposalSteps {
+    return steps.map((group) =>
+      group.map((step) => ({
+        ...step,
+        // "as any" should not be necessary but it is
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        data: this[method](step.data, replacements as any),
+      })),
+    );
+  }
+
+  replaceAllInProposal(
+    steps: ProposalSteps,
+    replacements: Replacements,
+  ): ProposalSteps {
+    return this.replaceAllInProposalWithMethod(
+      "replaceAll",
+      steps,
+      replacements,
+    );
+  }
+
+  replaceAllWithStringsInProposal(
+    steps: ProposalSteps,
+    replacements: StringReplacements,
+  ): ProposalSteps {
+    return this.replaceAllInProposalWithMethod(
+      "replaceAllWithStrings",
+      steps,
+      replacements,
+    );
+  }
+}
+
+function bigNumberTo32Bytes(number: BigNumberish): string {
+  const bn = BigNumber.from(number);
+  if (bn.gt(ethers.constants.MaxUint256)) {
+    throw new Error(`Number is too large to represent in 32 bytes: ${bn}`);
+  }
+  return utils.hexZeroPad(bn.toHexString(), 32).slice(2);
+}

--- a/src/proposals/make-vcow-swappable/README.md
+++ b/src/proposals/make-vcow-swappable/README.md
@@ -12,8 +12,7 @@ npx hardhat make-swappable --settings ./settings.json --network mainnet
 
 The file `settings.json` included in this repo is the one that will be used in the proposal.
 
-This script is deterministic and can be used to verify the transactions proposed to the Cow DAO by comparing the transaction hashes.
+If the values for `atomsToTransfer` or `bridged.atomsToTransfer` are not included in the settings file, placeholder strings will be used in place of the expected amounts.
 
 The output files are in the `output/deployment` folder, which include:
 1. `steps.json`, a list of transactions to be executed from the Cow DAO in the proposal.
-2. `txhashes.json`, the hashes of all transactions appearing in the proposal. They can be used to verify that the proposal was created correctly.

--- a/src/proposals/make-vcow-swappable/settings.json
+++ b/src/proposals/make-vcow-swappable/settings.json
@@ -1,11 +1,9 @@
 {
   "cowToken": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
   "virtualCowToken": "0xd057b63f5e69cf1b929b356b579cba08d7688048",
-  "atomsToTransfer": "123456000000000000000000",
   "multisend": "0x8d29be29923b68abfdd21e541b9374737b49cdad",
   "multiTokenMediator": "0x88ad09518695c6c3712AC10a214bE5109a655671",
   "bridged": {
-    "virtualCowToken": "0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB",
-    "atomsToTransfer": "7891011000000000000000000"
+    "virtualCowToken": "0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB"
   }
 }

--- a/test/lib/replacer.test.ts
+++ b/test/lib/replacer.test.ts
@@ -1,0 +1,107 @@
+import { expect } from "chai";
+import { ethers } from "ethers";
+import { Interface } from "ethers/lib/utils";
+
+import { CalldataReplacer } from "../../src/lib";
+
+describe("replacer", function () {
+  const encoder = new Interface([
+    "function oneInput(uint256)",
+    "function twoInputs(uint256,uint256)",
+    "function threeInputs(uint256,uint256,uint256)",
+  ]);
+
+  it("replaces calldata", function () {
+    const replacer = new CalldataReplacer("test");
+
+    const placeholder = replacer.generateUint256Placeholder("key");
+    expect(
+      replacer.replaceAll(
+        encoder.encodeFunctionData("oneInput", [placeholder]),
+        {
+          key: 1337,
+        },
+      ),
+    ).to.equal(encoder.encodeFunctionData("oneInput", [1337]));
+  });
+
+  it("replaces repeating calldata", function () {
+    const replacer = new CalldataReplacer("test");
+
+    const placeholder = replacer.generateUint256Placeholder("key");
+    expect(
+      replacer.replaceAll(
+        encoder.encodeFunctionData("twoInputs", [placeholder, placeholder]),
+        {
+          key: 1337,
+        },
+      ),
+    ).to.equal(encoder.encodeFunctionData("twoInputs", [1337, 1337]));
+  });
+
+  it("replaces multiple values", function () {
+    const replacer = new CalldataReplacer("test");
+
+    const ph1 = replacer.generateUint256Placeholder("key1");
+    const ph2 = replacer.generateUint256Placeholder("key2");
+    const ph3 = replacer.generateUint256Placeholder("key3");
+    const replacements = { key1: 1337, key2: 31337, key3: 42 };
+    // Changing the order to make sure it doesn't influence the result.
+    const placeholders = [ph1, ph3, ph2];
+    const actual = [1337, 42, 31337];
+    expect(
+      replacer.replaceAll(
+        encoder.encodeFunctionData("threeInputs", placeholders),
+        replacements,
+      ),
+    ).to.equal(encoder.encodeFunctionData("threeInputs", actual));
+  });
+
+  describe("placeholder", function () {
+    it("is deterministic", function () {
+      const replacer1 = new CalldataReplacer("test");
+      const replacer2 = new CalldataReplacer("test");
+      expect(replacer1.generateUint256Placeholder("key")).to.equal(
+        replacer2.generateUint256Placeholder("key"),
+      );
+    });
+
+    it("depends on seed", function () {
+      const replacer1 = new CalldataReplacer("test1");
+      const replacer2 = new CalldataReplacer("test2");
+      expect(replacer1.generateUint256Placeholder("key")).not.to.equal(
+        replacer2.generateUint256Placeholder("key"),
+      );
+    });
+  });
+
+  it("throws if key to replace is missing", function () {
+    const replacer = new CalldataReplacer("test");
+
+    replacer.generateUint256Placeholder("key");
+    expect(() => replacer.replaceAll("", {})).to.throw(
+      Error,
+      "The following keys should be replaced and are missing: key",
+    );
+  });
+
+  it("throws if there are extra keys to replace", function () {
+    const replacer = new CalldataReplacer("test");
+
+    expect(() => replacer.replaceAll("", { key: "1337" })).to.throw(
+      Error,
+      "The following keys were specified to be replaced but the corresponding placeholder was not found: key",
+    );
+  });
+
+  it("throws if trying to replace a very large number", function () {
+    const replacer = new CalldataReplacer("test");
+
+    expect(() =>
+      replacer.replaceAll("", { key: ethers.constants.MaxUint256.add(1) }),
+    ).to.throw(
+      Error,
+      "Number is too large to represent in 32 bytes: 115792089237316195423570985008687907853269984665640564039457584007913129639936",
+    );
+  });
+});


### PR DESCRIPTION
As we don't know the amount that will be used at the moment of proposal execution, but we would like to get all the calldata in advance for voting, we change the proposal so that the yet unknown data is replaced with placeholder letters.

The script can be run in two modes: without specifying the amounts, which replaces the unknown calldata with placeholders, and with the amounts, which then return the full calldata.

As a consequence of the changes, we don't compute the Snapshot hash (because the calldata isn't always known and we don't need to verify the hash as the proposal won't be executed by snapshot).

### Test Plan

New unit tests. Also, two manual tests:
1. compare the output of the script before the pr and the output of the script in this PR _when adding back the atom amounts in the settings file_. There is not difference.
2. Compare the output from point 1. to the output of the script in this PR without any change. Result:
![diff](https://user-images.githubusercontent.com/58218759/156738388-e95db709-198d-4620-b652-1d0b6532333a.png)
